### PR TITLE
Change Gander icon from duck to goose

### DIFF
--- a/HSMascotMap.ultra
+++ b/HSMascotMap.ultra
@@ -376,7 +376,6 @@ style:
             - icons8-dots-64
 
             - - Ducks
-              - Ganders
             - icons8-duck-64
 
             - - Dwarfs
@@ -515,6 +514,7 @@ style:
             - icons8-hippo-64
 
             - - Honkers
+              - Ganders
               - Goslings
             - icons8-goose-64
 

--- a/HSMascotMap_QLever.ultra
+++ b/HSMascotMap_QLever.ultra
@@ -381,7 +381,6 @@ controls:
             - icons8-dots-64
 
             - - Ducks
-              - Ganders
             - icons8-duck-64
 
             - - Dwarfs
@@ -520,6 +519,7 @@ controls:
             - icons8-hippo-64
 
             - - Honkers
+              - Ganders
               - Goslings
             - icons8-goose-64
 

--- a/HSMascotMap_global.ultra
+++ b/HSMascotMap_global.ultra
@@ -375,7 +375,6 @@ style:
             - icons8-dots-64
 
             - - Ducks
-              - Ganders
             - icons8-duck-64
 
             - - Dwarfs
@@ -514,6 +513,7 @@ style:
             - icons8-hippo-64
 
             - - Honkers
+              - Ganders
               - Goslings
             - icons8-goose-64
 

--- a/HSMascotMap_university_global.ultra
+++ b/HSMascotMap_university_global.ultra
@@ -375,7 +375,6 @@ style:
             - icons8-dots-64
 
             - - Ducks
-              - Ganders
             - icons8-duck-64
 
             - - Dwarfs
@@ -514,6 +513,7 @@ style:
             - icons8-hippo-64
 
             - - Honkers
+              - Ganders
               - Goslings
             - icons8-goose-64
 

--- a/NewMascots.txt
+++ b/NewMascots.txt
@@ -9,11 +9,13 @@ Big Blue
 Big Reds
 Black Scots
 Blackscots
+Blazer Bees
 Blue Darters
 Blue Devil
 Blue Hoses
 Blue Jackets
 Blue Streaks
+Blue Tornado
 Blue Whales
 Bluejackets
 Blues
@@ -40,6 +42,7 @@ Copper Kings
 Cotton Pickers
 Cowboys;Cowgirls
 Crickets
+Crimson Wave
 Cruisers
 Dalers
 Darts
@@ -50,6 +53,7 @@ Dragonflies
 Exporters
 Fillies;Mustangs
 Flash
+Flying Flucos
 Foxberry
 Gila Monsters
 Goldburgs
@@ -83,6 +87,7 @@ Magic
 Maniacs
 Marmots
 Maroon
+Maroon Tide
 Maroons
 Minutemen
 Missiles
@@ -115,6 +120,7 @@ Red Riots
 Red Tails
 Renegades
 Rocks
+Rockstars
 Sachems
 Sages
 Sandies;Sandiettes
@@ -122,6 +128,8 @@ Savages
 Saxons
 Sequoits
 Slicers
+Snow Leopards
+Soaring Hawks
 Springers
 Squirrels
 Stanners
@@ -158,6 +166,7 @@ Volunteers
 Voyagers
 Voyageurs
 Wamps
+Wave
 Wheelers
 Whundas
 Wild

--- a/Style.ultra
+++ b/Style.ultra
@@ -364,7 +364,6 @@ style:
             - icons8-dots-64
 
             - - Ducks
-              - Ganders
             - icons8-duck-64
 
             - - Dwarfs
@@ -503,6 +502,7 @@ style:
             - icons8-hippo-64
 
             - - Honkers
+              - Ganders
               - Goslings
             - icons8-goose-64
 


### PR DESCRIPTION
Ganders were introduced by me in https://github.com/watmildon/HighSchoolMascotMap/pull/2, when there wasn't a goose icon yet. Now there is.